### PR TITLE
Fix Fallout New Vegas detection

### DIFF
--- a/installers/vortex.yml
+++ b/installers/vortex.yml
@@ -157,7 +157,7 @@ script:
     - task:
         name: set_regedit
         prefix: $GAMEDIR
-        path: HKEY_LOCAL_MACHINE\Software\Wow6432Node\Bethesda Softworks\Fallout New Vegas
+        path: HKEY_LOCAL_MACHINE\Software\Wow6432Node\Bethesda Softworks\FalloutNV
         type: REG_SZ
         key: "Installed Path"
         value: c:\\program files (x86)\\steam\\steamapps\\common\\Fallout New Vegas


### PR DESCRIPTION
According to [regfiles.net](https://www.regfiles.net/registry/fallout-new-vegas-registry) the registry entry for Fallout New Vegas should be `FalloutNV` but the installer had it as `Fallout New Vegas` which is probably what's causing #12.