### PR TITLE
Warn users about updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Plug and play installation, everything configured out of the box for games insta
 
 Support for other games can be added through a few edits to the installer (see the "ADD SUPPORT FOR GAMES" section).
 
-## Disable Updates
+### Disable Updates
 
 Vortex is tested and guaranteed to have basic functionality working with the versions supplied by the installers. Updates to either Vortex or Wine have been shown to break things very often.
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Plug and play installation, everything configured out of the box for games insta
 
 Support for other games can be added through a few edits to the installer (see the "ADD SUPPORT FOR GAMES" section).
 
-## Do Not Update Anything
+## Disable Updates
 
 Vortex is tested and guaranteed to have basic functionality working with the versions supplied by the installers. Updates to either Vortex or Wine have been shown to break things very often.
+
+Updates can be disabled by going to `Settings > Vortex > Update` and selecting the option 'No automatic updates'.
 
 ### WORKING GAMES:
 - TESV: Skyrim Special Edition

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Vortex is tested and guaranteed to have basic functionality working with the ver
 
 Updates can be disabled by going to `Settings > Vortex > Update` and selecting the option 'No automatic updates'.
 
+If your current installation is broken because of an update, you can reinstall an older version by downloading an installer from [here](https://github.com/Nexus-Mods/Vortex/releases) and running it inside Vortex's prefix: in Lutris, right click the application and use the option 'Run EXE inside wine prefix'
+
 ### WORKING GAMES:
 - TESV: Skyrim Special Edition
 - TESV: Skyrim

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Plug and play installation, everything configured out of the box for games insta
 
 Support for other games can be added through a few edits to the installer (see the "ADD SUPPORT FOR GAMES" section).
 
+## Do Not Update Anything
+
+Vortex is tested and guaranteed to have basic functionality working with the versions supplied by the installers. Updates to either Vortex or Wine have been shown to break things very often.
+
 ### WORKING GAMES:
 - TESV: Skyrim Special Edition
 - TESV: Skyrim


### PR DESCRIPTION
Since I haven't been able to test newer version as much as I would like to it's natural that users will want to update things on their own. Updates to both Vortex and Wine have been causing issues recently, so it's important to make sure users are warned about the problems these updates can cause.