### PR TITLE
Fix Nexus Manager links

### DIFF
--- a/runners/vortex-downloads-handler.desktop
+++ b/runners/vortex-downloads-handler.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Categories=Game;
 Path=<VORTEX_PREFIX>/drive_c/Program Files/Black Tree Gaming Ltd/Vortex
-Exec=env WINEPREFIX="<VORTEX_PREFIX>" PATH="<HOME>/.local/share/lutris/runners/wine/lutris-4.12.1-x86_64/bin:$PATH" wine Vortex.exe -d %u
+Exec=env WINEPREFIX="<VORTEX_PREFIX>" PATH="<HOME>/.local/share/lutris/runners/wine/lutris-5.2-x86_64/bin:$PATH" wine Vortex.exe -d %u
 Name=Vortex
 MimeType=x-scheme-handler/nxm;x-scheme-handler/nxm-protocol
 NoDisplay=true


### PR DESCRIPTION
The Wine version in the downloads handler runner was incorrectly set, which broke the handling of Nexus Mod Manager links