### PR TITLE
Patch OBSE to run from within MO2

### DIFF
--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -139,6 +139,11 @@ script:
     - extract:
         file: obse
         dst: $CACHE/oblivion-script-extender/
+    # patch OBSE to not complain about running outside of Steam
+    - execute:
+        command: |-
+           printf '\x90\x90\x90' | dd conv=notrunc of='$CACHE/oblivion-script-extender/obse_loader.exe' bs=1 seek=$((0x14cb))
+
 
     - extract:
         file: skse


### PR DESCRIPTION
As commented in #23 OBSE cannot not be started from within Mod Organizer 2 without a patch