### PR TITLE
Wine support

### DIFF
--- a/gamesinfo/fallout3.sh
+++ b/gamesinfo/fallout3.sh
@@ -14,6 +14,8 @@ else
 	game_steam_subdirectory="Fallout 3 goty"
 fi
 game_appid=$fo3_appid
-game_launcher_options="--restart-pulse --protonver 5.*"
+game_proton_options="--restart-pulse --protonver 5.*"
+game_wine_options="--restart-pulse"
 game_protontricks="d3dcompiler_43 d3dx9"
+game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/fallout4.sh
+++ b/gamesinfo/fallout4.sh
@@ -1,5 +1,7 @@
 game_steam_subdirectory="Fallout 4"
 game_appid=377160
-game_launcher_options="--restart-pulse --native 'xaudio2_7' --protonver 5.*"
+game_proton_options="--restart-pulse --native 'xaudio2_7' --protonver 5.*"
+game_wine_options="--restart-pulse --native 'xaudio2_7'"
 game_protontricks=""
+game_winetricks=""
 

--- a/gamesinfo/morrowind.sh
+++ b/gamesinfo/morrowind.sh
@@ -1,5 +1,7 @@
 game_steam_subdirectory="Morrowind"
 game_appid=22320
-game_launcher_options="--restart-pulse --protonver 5.*"
+game_proton_options="--restart-pulse --protonver 5.*"
+game_wine_options="--restart-pulse"
 game_protontricks="d3dcompiler_43 d3dx9"
+game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/newvegas.sh
+++ b/gamesinfo/newvegas.sh
@@ -1,5 +1,7 @@
 game_steam_subdirectory="Fallout New Vegas"
 game_appid=22380
-game_launcher_options="--restart-pulse --protonver 5.*"
+game_proton_options="--restart-pulse --protonver 5.*"
+game_wine_options="--restart-pulse"
 game_protontricks="d3dcompiler_43 d3dx9"
+game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/oblivion.sh
+++ b/gamesinfo/oblivion.sh
@@ -1,5 +1,7 @@
 game_steam_subdirectory="Oblivion"
 game_appid=22330
-game_launcher_options="--restart-pulse --protonver 5.*"
+game_proton_options="--restart-pulse --protonver 5.*"
+game_wine_options="--restart-pulse"
 game_protontricks="d3dcompiler_43 d3dx9"
+game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/skyrim.sh
+++ b/gamesinfo/skyrim.sh
@@ -1,5 +1,7 @@
 game_steam_subdirectory="Skyrim"
 game_appid=72850
-game_launcher_options="--restart-pulse --protonver 5.*"
+game_proton_options="--restart-pulse --protonver 5.*"
+game_wine_options="--restart-pulse"
 game_protontricks="d3dcompiler_43 d3dx9"
+game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/skyrimspecialedition.sh
+++ b/gamesinfo/skyrimspecialedition.sh
@@ -1,5 +1,7 @@
 game_steam_subdirectory="Skyrim Special Edition"
 game_appid=489830
-game_launcher_options="--restart-pulse --native 'xaudio2_7' --protonver 5.*"
+game_proton_options="--restart-pulse --native 'xaudio2_7' --protonver 5.*"
+game_wine_options="--restart-pulse --native 'xaudio2_7'"
 game_protontricks=""
+game_winetricks=""
 

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -9,17 +9,17 @@ script:
 
     files:
     # utils
-    - dialog: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.2.0-utils/dialog.sh
-    - find_library_for_appid: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.2.0-utils/find-library-for-appid.sh
+    - dialog: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-utils/dialog.sh
+    - find_library_for_appid: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-utils/find-library-for-appid.sh
 
     # supported games info
-    - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.3.0-gamesinfo/gamesinfo.tar.gz
+    - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-gamesinfo/gamesinfo.tar.gz
 
     # mo2/game runners
-    - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.2.0-runners/proton-launcher.sh
-    - wine_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.2.0-runners/wine-launcher.sh
-    - nxm_broker: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.2.0-runners/modorganizer2-nxm-broker.sh
-    - nxm_mime_handler: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.2.0-runners/modorganizer2-nxm-handler.desktop
+    - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-runners/proton-launcher.sh
+    - wine_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-runners/wine-launcher.sh
+    - nxm_broker: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-runners/modorganizer2-nxm-broker.sh
+    - nxm_mime_handler: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-runners/modorganizer2-nxm-handler.desktop
 
     # modding tools
     - openjdk: https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_x64_windows_8u252b09.zip

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -245,6 +245,10 @@ script:
             # workaround to stop installation if command fails
             echo "success" > '$CACHE/successful-prefix-preparation'
 
+        env:
+            GAMEDIR: $GAMEDIR
+            CACHE: $CACHE
+
     - move: # raises error if command fails
         src: $CACHE/successful-prefix-preparation
         dst: $CACHE/successful-prefix-preparation-acknowledged

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -9,8 +9,8 @@ script:
 
     files:
     # utils
-    - dialog: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-utils/dialog.sh
-    - find_library_for_appid: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-utils/find-library-for-appid.sh
+    - dialog: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.0-utils/dialog.sh
+    - find_library_for_appid: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.0-utils/find-library-for-appid.sh
 
     # supported games info
     - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-gamesinfo/gamesinfo.tar.gz
@@ -181,6 +181,7 @@ script:
             case "$runner" in
                 proton)
                     mo2_tricks="vcrun2019"
+                    mo2_options=""
 
                     steam_library=$("$CACHE/utils/find-library-for-appid.sh" $game_appid)
 
@@ -195,16 +196,20 @@ script:
                     game_tricks="$game_protontricks"
 
                     echo -e \
-                    "#!/bin/bash\n\n'$shared/proton-launcher.sh' $game_proton_options \"\$@\" $game_appid '$GAMEDIR/ModOrganizer2/ModOrganizer.exe'" \
+                    "#!/bin/bash\n\n'$shared/proton-launcher.sh' $mo2_options $game_proton_options \"\$@\" $game_appid '$GAMEDIR/ModOrganizer2/ModOrganizer.exe'" \
                     > "$GAMEDIR/run.sh"
 
                     echo -e \
-                    "#!/bin/bash\n\n'$shared/proton-launcher.sh' $game_proton_options \"\$@\" $game_appid '$GAMEDIR/ModOrganizer2/nxmhandler.exe' \"\$1\"" \
+                    "#!/bin/bash\n\n'$shared/proton-launcher.sh' $mo2_options $game_proton_options \"\$@\" $game_appid '$GAMEDIR/ModOrganizer2/nxmhandler.exe' \"\$1\"" \
                     > "$GAMEDIR/download.sh"
                     ;;
 
                 wine)
                     mo2_tricks="vcrun2019 dotnet40"
+                    mo2_options="--proton-wine --winever 5.*"
+
+                    "$CACHE/utils/dialog.sh" warnbox \
+                        "As of version 5.7, Wine still does not fully support Mod Organizer 2.2.1 and later.\nFor this reason this installer uses the Wine version bundled with Proton 5.0.\nMake sure you have Steam and Proton 5.0 installed on your system"
 
                     game_prefix=$( \
                         "$CACHE/utils/dialog.sh" directorypicker \
@@ -253,22 +258,23 @@ script:
                         fi
                     fi
 
-                    winever=$( \
-                        "$CACHE/utils/dialog.sh" textentry \
-                            "Inform which version of Wine you're using\nLeave as * to use the latest version available on Lutris" \
-                            "*" \
-                    )
-                    if [ -z "$winever" ]; then
-                        echo "ERROR: Installation canceled by user" >&2
-                        exit 1
-                    fi
+                    # TODO: uncomment once Wine fixes issues with VC2019
+                    # winever=$( \
+                    #     "$CACHE/utils/dialog.sh" textentry \
+                    #         "Inform which version of Wine you're using\nLeave as * to use the latest version available on Lutris" \
+                    #         "*" \
+                    # )
+                    # if [ -z "$winever" ]; then
+                    #     echo "ERROR: Installation canceled by user" >&2
+                    #     exit 1
+                    # fi
 
                     echo -e \
-                    "#!/bin/bash\n\nWINEPREFIX='$game_prefix' '$shared/wine-launcher.sh' --winever '$winever' $game_wine_options \"\$@\" '$GAMEDIR/ModOrganizer2/ModOrganizer.exe'" \
+                    "#!/bin/bash\n\nWINEPREFIX='$game_prefix' '$shared/wine-launcher.sh' $mo2_options $game_wine_options \"\$@\" '$GAMEDIR/ModOrganizer2/ModOrganizer.exe'" \
                     > "$GAMEDIR/run.sh"
 
                     echo -e \
-                    "#!/bin/bash\n\nWINEPREFIX='$game_prefix' '$shared/wine-launcher.sh' --winever '$winever' $game_wine_options \"\$@\" '$GAMEDIR/ModOrganizer2/nxmhandler.exe'" \
+                    "#!/bin/bash\n\nWINEPREFIX='$game_prefix' '$shared/wine-launcher.sh' $mo2_options $game_wine_options \"\$@\" '$GAMEDIR/ModOrganizer2/nxmhandler.exe'" \
                     > "$GAMEDIR/download.sh"
                     ;;
             esac

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -245,10 +245,6 @@ script:
             # workaround to stop installation if command fails
             echo "success" > '$CACHE/successful-prefix-preparation'
 
-        env:
-            GAMEDIR: $GAMEDIR
-            CACHE: $CACHE
-
     - move: # raises error if command fails
         src: $CACHE/successful-prefix-preparation
         dst: $CACHE/successful-prefix-preparation-acknowledged

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -157,88 +157,154 @@ script:
     ###    prepare prefix    ###
     - execute:
         command: |
-            mo2_protontricks="vcrun2019"
-
             nexus_game_id=$INPUT_NEXUS_GAME_ID
             runner=$INPUT_RUNNER
 
-            if [ "$runner" == "proton" ]; then
-                if [ ! -f "$CACHE/gamesinfo/$nexus_game_id.sh" ]; then
-                    "$CACHE/utils/dialog.sh" errorbox \
-                        "Could not find gameinfo for '$nexus_game_id', remove Lutris cache and try again"
-                    exit 1
-                fi
+            if [ ! -f "$CACHE/gamesinfo/$nexus_game_id.sh" ]; then
+                "$CACHE/utils/dialog.sh" errorbox \
+                    "Could not find gameinfo for '$nexus_game_id', remove Lutris cache and try again"
+                exit 1
+            fi
 
-                source "$CACHE/gamesinfo/$nexus_game_id.sh"
+            source "$CACHE/gamesinfo/$nexus_game_id.sh"
 
-                if [ -z "$game_appid" ]; then
-                    echo "ERROR: empty game_appid" >&2
-                    exit 1
-                elif [ -z "$game_steam_subdirectory" ]; then
-                    echo "ERROR: empty steam_subdirectory" >&2
-                    exit 1
-                fi
+            if [ -z "$game_appid" ]; then
+                echo "ERROR: empty game_appid" >&2
+                exit 1
+            elif [ -z "$game_steam_subdirectory" ]; then
+                echo "ERROR: empty steam_subdirectory" >&2
+                exit 1
+            fi
 
-                steam_library=$("$CACHE/utils/find-library-for-appid.sh" $game_appid)
+            shared="$HOME/.local/share/modorganizer2"
 
-                if [ ! -d "$steam_library" ]; then
-                    "$CACHE/utils/dialog.sh" errorbox \
-                        "Could not find '$game_steam_subdirectory' in your Steam library"
-                    exit 1
-                fi
+            case "$runner" in
+                proton)
+                    mo2_tricks="vcrun2019"
 
-                game_prefix="$steam_library/steamapps/compatdata/$game_appid/pfx"
-                game_installation="$steam_library/steamapps/common/$game_steam_subdirectory"
+                    steam_library=$("$CACHE/utils/find-library-for-appid.sh" $game_appid)
 
-                if [ -d "$CACHE/${nexus_game_id}-script-extender" ]; then
-                    echo "Installing script extender..."
-
-                    output=$( \
-                        cp -af \
-                        "$CACHE/${nexus_game_id}-script-extender/." \
-                        "$game_installation/" 2>&1 \
-                    )
-                    if [ "$?" != "0" ]; then
+                    if [ ! -d "$steam_library" ]; then
                         "$CACHE/utils/dialog.sh" errorbox \
-                            "Error while installing script extender: $output"
+                            "Could not find '$game_steam_subdirectory' in your Steam library"
                         exit 1
                     fi
-                fi
 
-                mkdir -p "$game_prefix/drive_c/java"
+                    game_prefix="$steam_library/steamapps/compatdata/$game_appid/pfx"
+                    game_installation="$steam_library/steamapps/common/$game_steam_subdirectory"
+                    game_tricks="$game_protontricks"
+
+                    echo -e \
+                    "#!/bin/bash\n\n'$shared/proton-launcher.sh' $game_proton_options \"\$@\" $game_appid '$GAMEDIR/ModOrganizer2/ModOrganizer.exe'" \
+                    > "$GAMEDIR/run.sh"
+
+                    echo -e \
+                    "#!/bin/bash\n\n'$shared/proton-launcher.sh' $game_proton_options \"\$@\" $game_appid '$GAMEDIR/ModOrganizer2/nxmhandler.exe' \"\$1\"" \
+                    > "$GAMEDIR/download.sh"
+                    ;;
+
+                wine)
+                    mo2_tricks="vcrun2019 dotnet40"
+
+                    game_prefix=$( \
+                        "$CACHE/utils/dialog.sh" directorypicker \
+                            "Inform the path to your wineprefix" \
+                    )
+                    if [ -z "$game_prefix" ]; then
+                        echo "ERROR: Installation canceled by user" >&2
+                        exit 1
+                    fi
+
+                    game_tricks="$game_winetricks"
+
+                    install_path_candidates=( \
+                        "$game_prefix/drive_c/Program Files (x86)/Steam/steamapps/common/$game_steam_subdirectory" \
+                        "$game_prefix/drive_c/GOG Games/$game_steam_subdirectory" \
+                    )
+                    if [ -n "$game_gog_subdirectory" ]; then
+                        install_path_candidates+=( \
+                            "$game_prefix/drive_c/GOG Games/$game_gog_subdirectory" \
+                        )
+                    fi
+                    if [ "$nexus_game_id" == "fallout3" ]; then
+                        install_path_candidates+=( \
+                            "$game_prefix/drive_c/Program Files (x86)/Steam/steamapps/common/Fallout 3" \
+                            "$game_prefix/drive_c/GOG Games/Fallout 3" \
+                        )
+                    fi
+
+                    for path in "${install_path_candidates[@]}"; do
+                        echo "Searching for game at '$path'"
+                        if [ -d "$path" ]; then
+                            echo "Found game"
+                            game_installation="$path"
+                            break
+                        fi
+                    done
+
+                    if [ -z "$game_installation" ]; then
+                        game_installation=$( \
+                            "$CACHE/utils/dialog.sh" directorypicker \
+                                "Could not automatically find the game.\nPlease inform the path where the game is installed" \
+                        )
+                        if [ -z "$game_installation" ]; then
+                            echo "ERROR: installation canceled by user" >&2
+                            exit 1
+                        fi
+                    fi
+
+                    winever=$( \
+                        "$CACHE/utils/dialog.sh" textentry \
+                            "Inform which version of Wine you're using\nLeave as * to use the latest version available on Lutris" \
+                            "*" \
+                    )
+                    if [ -z "$winever" ]; then
+                        echo "ERROR: Installation canceled by user" >&2
+                        exit 1
+                    fi
+
+                    echo -e \
+                    "#!/bin/bash\n\nWINEPREFIX='$game_prefix' '$shared/wine-launcher.sh' --winever '$winever' $game_wine_options \"\$@\" '$GAMEDIR/ModOrganizer2/ModOrganizer.exe'" \
+                    > "$GAMEDIR/run.sh"
+
+                    echo -e \
+                    "#!/bin/bash\n\nWINEPREFIX='$game_prefix' '$shared/wine-launcher.sh' --winever '$winever' $game_wine_options \"\$@\" '$GAMEDIR/ModOrganizer2/nxmhandler.exe'" \
+                    > "$GAMEDIR/download.sh"
+                    ;;
+            esac
+
+            if [ -d "$CACHE/${nexus_game_id}-script-extender" ]; then
+                echo "Installing script extender..."
+
                 output=$( \
                     cp -af \
-                    "$CACHE/extracted-openjdk/." \
-                    "$game_prefix/drive_c/java/" 2>&1 \
+                    "$CACHE/${nexus_game_id}-script-extender/." \
+                    "$game_installation/" 2>&1 \
                 )
                 if [ "$?" != "0" ]; then
                     "$CACHE/utils/dialog.sh" errorbox \
-                        "Error while installing OpenJDK: $output"
+                        "Error while installing script extender: $output"
                     exit 1
                 fi
+            fi
 
-                WINEPREFIX="$game_prefix" \
-                "$HOME/.local/share/lutris/runtime/winetricks/winetricks" -q $mo2_protontricks $game_protontricks
-                if [ "$?" != "0" ]; then
-                    "$CACHE/utils/dialog.sh" errorbox \
-                        "Error while installing winetricks, please run Lutris from a terminal and check the logs"
-                    exit 1
-                fi
-
-                shared="$HOME/.local/share/modorganizer2"
-
-                echo -e \
-                "#!/bin/bash\n\n'$shared/proton-launcher.sh' $game_launcher_options $game_appid '$GAMEDIR/ModOrganizer2/ModOrganizer.exe'" \
-                > "$GAMEDIR/run.sh"
-
-                echo -e \
-                "#!/bin/bash\n\n'$shared/proton-launcher.sh' $game_launcher_options $game_appid '$GAMEDIR/ModOrganizer2/nxmhandler.exe' \"\$1\"" \
-                > "$GAMEDIR/download.sh"
-
-
-            elif [ "$runner" == "wine" ]; then
+            mkdir -p "$game_prefix/drive_c/java"
+            output=$( \
+                cp -af \
+                "$CACHE/extracted-openjdk/." \
+                "$game_prefix/drive_c/java/" 2>&1 \
+            )
+            if [ "$?" != "0" ]; then
                 "$CACHE/utils/dialog.sh" errorbox \
-                    "Installation for custom Wine prefixes not yet supported"
+                    "Error while installing OpenJDK: $output"
+                exit 1
+            fi
+
+            WINEPREFIX="$game_prefix" \
+            "$HOME/.local/share/lutris/runtime/winetricks/winetricks" -q $mo2_tricks $game_tricks
+            if [ "$?" != "0" ]; then
+                "$CACHE/utils/dialog.sh" errorbox \
+                    "Error while installing winetricks, please run Lutris from a terminal and check the logs"
                 exit 1
             fi
 

--- a/runners/wine-launcher.sh
+++ b/runners/wine-launcher.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
-SKYRIM_PROTON_BINARY="$HOME/.steam/steam/steamapps/common/Proton 4.11/proton"
-SKYRIM_INSTALL_FOLDER="$HOME/.steam/steam/steamapps/common/Skyrim Special Edition"
-
 script=$0
 
 print_help() {
 cat << EOF
 
-Usage: $script [OPTIONS...] APPID EXECUTABLE [EXECUTABLE_ARGS...]
+Usage: $script [OPTIONS...] EXECUTABLE [EXECUTABLE_ARGS...]
 
 Launch arbitrary executables inside a Steam game's Proton prefix
+Remember to specify the wine prefix with the environment variable WINEPREFIX
 
 APPID:			APPID for the Steam game
 			visit https://steamdb.info to a game's APPID
@@ -20,11 +18,6 @@ EXECUTABLE:		path to the .exe file to execute
 EXECUTABLE_ARGS:	arguments to pass to EXECUTABLE
 
 OPTIONS:
-	--d9vk		use DXVK instead of wined3d on DirectX9 apps
-			obsolete on Proton 5.0 or newer
-
-	--directx9	force EXECUTABLE to use DirectX9
-
 	-e,--env	send custom environment variable to Proton
 
 	--int-scaling	enable integer scaling
@@ -33,25 +26,25 @@ OPTIONS:
 			should be a quoted space-separated list
 			eg.: -n 'xaudio2_7 d3d9'
 
-	--noesync	run without esync
-
-	--nofsync	run without fsync
-
-	-p,--protonver	specify Proton version to use
+	-p,--winever	specify Proton version to use
 			defaults to the latest installed version
 			can be a Pearl regex
 			if a regex, the latest matching version is used
 
-	--proton-libdir	specify Steam library where to look for Proton
+	--wine-libdir	specify Steam library where to look for Proton
 			default is \$HOME/.steam/steam
 
 	--restart-pulse	restart pulseaudio right before running EXECUTABLE
 
+	--system-libs	prefer system libraries over
+			libraries supplied by Steam
+
+	--system-wine	use wine installed on the system
+			instead of versions supplied by Lutris
+
 	-w,--workdir	specify working directory for the entire script
 			the script switches to this directory
 			right after parsing all arguments
-
-	--wined3d	use wined3d instead of DXVK
 
 	-h,--help	print this help message and exit
 
@@ -84,9 +77,9 @@ else
 fi
 
 ###    DEFAULTS    ###
-protonver='*'
-proton_extra_envs=()
-proton_libdir="$HOME/.steam/steam"
+winever='*'
+wine_extra_envs=()
+wine_libdir="$HOME/.steam/steam"
 restart_pulse=false
 ###    DEFAULTS    ###
 
@@ -95,21 +88,12 @@ parsing_args=true
 while [ "$parsing_args" == "true" ]; do
 	argname=$1
 	case "$argname" in
-		--d9vk)
-			proton_extra_envs+=("PROTON_USE_D9VK=1"); shift 1
-			;;
-
-		--directx9)
-			proton_extra_envs+=("PROTON_NO_D3D10=1" "PROTON_NO_D3D11=1")
-			shift 1
-			;;
-
 		-e|--env)
-			proton_extra_envs+=("$2"); shift 2
+			wine_extra_envs+=("$2"); shift 2
 			;;
 
 		--int-scaling)
-			proton_extra_evs+=("WINE_FULLSCREEN_INTEGER_SCALING=1"); shift 1
+			wine_extra_evs+=("WINE_FULLSCREEN_INTEGER_SCALING=1"); shift 1
 			;;
 
 		-n|--native)
@@ -119,35 +103,31 @@ while [ "$parsing_args" == "true" ]; do
 				dll_overrides="$dll=n,b;$dll_overrides"
 			done
 
-			proton_extra_envs+=("WINEDLLOVERRIDES='$dll_overrides'")
+			wine_extra_envs+=("WINEDLLOVERRIDES='$dll_overrides'")
 			;;
 
-		--noesync)
-			proton_extra_envs+=("PROTON_NO_ESYNC=1"); shift 1
+		-p|--winever)
+			winever=$2; shift 2
 			;;
 
-		--nofsync)
-			proton_extra_envs+=("PROTON_NO_FSYNC=1"); shift 1
-			;;
-
-		-p|--protonver)
-			protonver=$2; shift 2
-			;;
-
-		--proton-libdir)
-			proton_libdir=$2; shift 2
+		--wine-libdir)
+			wine_libdir=$2; shift 2
 			;;
 
 		--restart-pulse)
 			restart_pulse=true; shift 1
 			;;
 
-		-w|--workdir)
-			workdir=$2; shift 2
+		--system-libs)
+			prefer_system_libs=true; shift 1
 			;;
 
-		--wined3d)
-			proton_extra_envs+=("PROTON_USE_WINED3D=1"); shift 1
+		--system-wine)
+			force_system_wine=true; shift 1
+			;;
+
+		-w|--workdir)
+			workdir=$2; shift 2
 			;;
 
 		-h|--help)
@@ -173,13 +153,6 @@ done
 ###    PARSE NAMED ARGS    ###
 
 ###    PARSE POSITIONAL ARGS    ###
-appid=$1; shift
-if [ -z "$appid" ]; then
-	echo "ERROR: please specify the APPID" >&2
-	print_help >&2
-	exit 1
-fi
-
 executable=$1; shift
 if [ -z "$executable" ]; then
 	echo "ERROR: please specify the EXECUTABLE" >&2
@@ -187,7 +160,6 @@ if [ -z "$executable" ]; then
 	exit 1
 fi
 ###    PARSE POSITIONAL ARGS    ###
-
 
 ###    ASSERT PATHS    ###
 if [ -n "$workdir" ]; then
@@ -202,56 +174,61 @@ if [ ! -f "$executable" ]; then
 fi
 ###    ASSERT PATHS    ###
 
-###    FIND GAME LIBRARY    ####
-if [ -n "$STEAM_LIBRARY" ]; then
-	compat_data="$STEAM_LIBRARY/steamapps/compatdata/$appid"
+###    FIND WINE EXECUTABLE    ###
+if [ "$force_system_wine" == "true" ]; then
+	wine_dir=$(realpath $(dirname $(readlink "/usr/bin/wine"))/..)
+	if [ ! -d "$wine_dir" ]; then
+		$errorbox "Could not locate Wine in your system"
+		print_help >&2
+		exit 1
+	fi
 else
-	steam_libraries=$( \
-		grep -oE '/[^"]+' "$HOME/.steam/steam/steamapps/libraryfolders.vdf" \
+	if [ "$winever" == "*" ]; then
+		version_match="/lutris-$winever"
+	else
+		version_match="$winever"
+	fi
+
+	wine_dir=$(find "$HOME/.local/share/lutris/runners/wine/" \
+			-maxdepth 1 -path "*$version_match*" \
+		|	sort -rV \
+		|	head -n 1
 	)
-	steam_libraries=$(echo -e "$HOME/.steam/steam\n$steam_libraries")
 
-	for libdir in $steam_libraries; do
-		echo "Searching for game in library '$libdir'"
-		compat_data="$libdir/steamapps/compatdata/$appid"
-		if [ -d "$compat_data" ]; then
-			echo "Found game"
-			break
-		fi
-	done
-fi
-
-if [ ! -d "$compat_data" ]; then
-	$errorbox "Could not find a game with APPID '$appid'"
-	print_help >&2
-	exit 1
-fi
-###    FIND GAME LIBRARY    ####
-
-###    FIND PROTON EXECUTABLE    ###
-proton_dir=$(find "$proton_libdir/steamapps/common/" \
-		-maxdepth 1 -path "*/Proton $protonver" \
-	|	sort -rV \
-	|	head -n 1
-)
-if [ ! -d "$proton_dir" ]; then
-	$errorbox "Could not find proton version matching '$protonver' in directory '$proton_libdir/steamapps/common/'"
-	print_help >&2
-	exit 1
-fi
-###    FIND PROTON EXECUTABLE    ###
-
-###    ASSERT STEAM RUNNING    ###
-if [ -z "$(pidof steam)" ]; then
-	$infobox "Steam must be running before continuing. Please start Steam"
-
-	if [ -z "$(pidof steam)" ]; then
-		$errorbox "Steam was not started, aborting"
-		echo "ERROR: Steam not running" >&2
+	if [ ! -d "$wine_dir" ]; then
+		$errorbox "Could not find wine version matching '$winever' in directory '$HOME/.local/share/lutris/runners/wine/'"
+		print_help >&2
 		exit 1
 	fi
 fi
-###    ASSERT STEAM RUNNING    ###
+###    FIND WINE EXECUTABLE    ###
+
+###    BUILD LD_LIBRARY_PATH    ###
+steam_dir="$HOME/.steam"
+if [ -d "$steam_dir" ]; then
+	steam_rundir=$(readlink "$steam_dir/bin32")/steam-runtime
+
+	steam_pinned_libs="$steam_rundir/pinned_libs_32:$steam_rundir/pinned_libs_64"
+
+	system_libs=$( \
+				ldconfig -N -v 2>/dev/null \
+			|	grep -oE '^/[^:]+' \
+			| tr '\n' ':' \
+			| sed 's/:$//' \
+	)
+
+	steam_32libs="$steam_rundir/i386/lib/i368-linux-gnu:$steam_rundir/i386/lib:$steam_rundir/i386/usr/lib/i386-linux-gnu:$steam_rundir/i386/usr/lib"
+	steam_64libs="$steam_rundir/amd64/lib/x86_64-linux-gnu:$steam_rundir/amd64/lib:$steam_rundir/amd64/usr/lib/x86_64-linux-gnu:$steam_rundir/amd64/usr/lib"
+
+	if [ "$prefer_system_libs" == "true" ]; then
+		library_path="$system_libs:$steam_pinned_libs:$steam_32libs:$steam_64libs"
+	else
+		library_path="$steam_pinned_libs:$system_libs:$steam_32libs:$steam_64libs"
+	fi
+else
+	library_path=""
+fi
+###    BUILD LD_LIBRARY_PATH    ###
 
 ###    RESET PULSEAUDIO    ###
 if [ "$restart_pulse" == "true" ]; then
@@ -263,22 +240,16 @@ fi
 ###    RESET PULSEAUDIO    ###
 
 ###    RUN EXECUTABLE    ###
-steam_dir=$(dirname "$proton_libdir")
-steam32_dir=$(readlink "$steam_dir/bin32")/steam-runtime
-
-run_proton="
-	PATH='$steam32_dir/amd64/usr/bin:$steam32_dir/usr/bin:$PATH' \\
-	LD_LIBRARY_PATH='$proton_dir/dist/lib64:$proton_dir/dist/lib:$steam32_dir/pinned_libs_32:$steam32_dir/pinned_libs_64' \\
-	STEAM_COMPAT_DATA_PATH='$compat_data' \\
-	SteamGameId=$appid \\
-	SteamAppId=$appid \\
-	${proton_extra_envs[@]} \\
+run_wine="
+	LD_LIBRARY_PATH='$library_path' \\
+	${wine_extra_envs[*]} \\
+	WINEPREFIX='$WINEPREFIX'
 	\\
-	'$proton_dir/proton' run '$executable' $@
+	'$wine_dir/bin/wine' '$executable' $([ -n "$1" ] && printf " '%s'" "$@")
 "
 
-echo -e "\n$run_proton\n"
+echo -e "\n$run_wine\n"
 
-bash -c "$run_proton"
+bash -c "$run_wine"
 ###    RUN EXECUTABLE    ###
 

--- a/utils/dialog.sh
+++ b/utils/dialog.sh
@@ -15,17 +15,6 @@ else
 	exit 1
 fi
 
-xtermbox() {
-	action_on_exit=$1
-	msg=$2
-	xterm -e bash -c "
-		echo '$msg'
-		echo
-		echo Press enter to $action_on_exit
-		read
-	"
-}
-
 errorbox() {
 	message=$1; shift
 	case "$interface" in
@@ -33,11 +22,11 @@ errorbox() {
 			zenity --ok-label=Exit --ellipsize --error --text "$message"
 			;;
 		xmessage)
-			xmessage -buttons exit:1 "$message"
+			xmessage -buttons exit:1 "ERROR: $message"
 			;;
 		xterm)
 			xterm -e bash -c "
-				echo '$message'
+				echo 'ERROR: $message'
 				echo
 				echo -n 'Press enter to exit. '
 				read
@@ -68,6 +57,26 @@ infobox() {
 	esac
 
 	return 0
+}
+
+warnbox() {
+	message=$1; shift
+	case "$interface" in
+		zenity)
+			zenity --ok-label=Continue --ellipsize --warning --text "$message"
+			;;
+		xmessage)
+			xmessage -buttons continue:0 "WARNING: $message"
+			;;
+		xterm)
+			xterm -e bash -c "
+				echo 'WARNING: $message'
+				echo
+				echo -n 'Press enter to continue. '
+				read
+			"
+			;;
+	esac
 }
 
 directorypicker() {

--- a/utils/dialog.sh
+++ b/utils/dialog.sh
@@ -136,6 +136,43 @@ directorypicker() {
 	esac
 }
 
+textentry() {
+	message=$1; shift
+	default_value=$1; shift
+	case "$interface" in
+		zenity)
+			entry_value=$(zenity --entry --entry-text="$default_value" --text "$message"); confirm=$?
+
+			if [ "$confirm" == "0" ]; then
+				echo "$entry_value"
+			fi
+
+			return $confirm
+			;;
+		xmessage|xterm)
+			tmpfile=$(mktemp /tmp/text-entry-XXXX)
+			xterm -e bash -c "
+				echo '$message'
+				echo 'Type (or leave empty to cancel) and press enter:'
+				read entry_value
+
+				if [ -z \"\$entry_value\" ]; then
+					exit 1
+				else
+					echo \"\$entry_value\" > $tmpfile
+				fi
+			"; confirm=$?
+
+			if [ "$confirm" == "0" ]; then
+				cat $tmpfile
+				rm $tmpfile
+			fi
+
+			return $confirm
+			;;
+	esac
+}
+
 $dialogtype "$@"
 exit $?
 


### PR DESCRIPTION
Added Wine support to the installer.

While the install process works fine, I could not get Wine to successfully run MO2. Using version 5.6 and older, there are problems with unimplemented functions in `vcruntime140_1.dll`. Using the latest 5.7 solves the unimplemented functions problem but MO2 crashes on startup with no clear error message. Setting `vcruntime140` and `vcruntime140_1` to native does not solve the issue.

Wine support is essential for users who bought their games on platforms other than Steam, as made evident in #23.