### PR TITLE
Change search path for custom Proton versions

### DIFF
--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -52,7 +52,7 @@ script:
         id: NEXUS_GAME_ID
         options:
             - fallout3: Fallout 3
-            - fallou4: Fallout 4
+            - fallout4: Fallout 4
             - newvegas: Fallout New Vegas
             - morrowind: Morrowind
             - oblivion: Oblivion

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -16,10 +16,10 @@ script:
     - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.4.0-gamesinfo/gamesinfo.tar.gz
 
     # mo2/game runners
-    - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.0-runners/proton-launcher.sh
-    - wine_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.0-runners/wine-launcher.sh
-    - nxm_broker: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.0-runners/modorganizer2-nxm-broker.sh
-    - nxm_mime_handler: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.0-runners/modorganizer2-nxm-handler.desktop
+    - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.1-runners/proton-launcher.sh
+    - wine_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.1-runners/wine-launcher.sh
+    - nxm_broker: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.1-runners/modorganizer2-nxm-broker.sh
+    - nxm_mime_handler: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.1-runners/modorganizer2-nxm-handler.desktop
 
     # modding tools
     - openjdk: https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_x64_windows_8u252b09.zip

--- a/runners/proton-launcher.sh
+++ b/runners/proton-launcher.sh
@@ -19,7 +19,7 @@ EXECUTABLE_ARGS:	arguments to pass to EXECUTABLE
 OPTIONS:
 	--customver	specify a custom version of proton to use
 			specified version must be a path within
-			\$HOME/.steam/steam/steamapps/common
+			\$HOME/.steam/compatibilitytools.d
 
 	--d9vk		use DXVK instead of wined3d on DirectX9 apps
 			obsolete on Proton 5.0 or newer
@@ -254,11 +254,13 @@ fi
 
 ###    FIND PROTON EXECUTABLE    ###
 if [ -n "$customver" ]; then
+	proton_search_path="$HOME/.steam/compatibilitytools.d/"
 	proton_match="$customver"
 else
+	proton_search_path="$proton_libdir/steamapps/common/"
 	proton_match="Proton $protonver"
 fi
-proton_dir=$(find "$proton_libdir/steamapps/common/" \
+proton_dir=$(find "$proton_search_path" \
 		-maxdepth 1 -path "*/$proton_match" \
 	|	sort -rV \
 	|	head -n 1

--- a/runners/wine-launcher.sh
+++ b/runners/wine-launcher.sh
@@ -199,11 +199,21 @@ case "$bin_supplier" in
 		;;
 
 	proton)
-		proton_dir=$(find "$HOME/.steam/steam/steamapps/common/" \
-				-maxdepth 1 -path "*Proton*$winever*" \
-			|	sort -rV \
-			| head -n 1 \
+		candidate_paths=( \
+			"$HOME/.steam/steam/steamapps/common/" \
+			"$HOME/.steam/compatibilitytools.d/" \
 		)
+		for search_path in "${candidate_paths[@]}"; do
+			proton_dir=$(find "$search_path" \
+					-maxdepth 1 -path "*Proton*$winever*" \
+				|	sort -rV \
+				|	head -n 1 \
+			)
+
+			if [ -d "$proton_dir" ]; then
+				break
+			fi
+		done
 
 		if [ ! -d "$proton_dir" ]; then
 			$errorbox "Could not find Proton version matching '$winever' in directory '$HOME/.steam/steam/steamapps/common/'"


### PR DESCRIPTION
Fixes #33 and #31

- Change search path for custom proton versions to $HOME/.steam/compatibilitytools.d
- Fix typo on Fallout 4 dropdown option

