### PR TITLE
Add noesync to Fallout 4 and option to override pulse-restart

### DIFF
--- a/gamesinfo/fallout4.sh
+++ b/gamesinfo/fallout4.sh
@@ -1,6 +1,6 @@
 game_steam_subdirectory="Fallout 4"
 game_appid=377160
-game_proton_options="--restart-pulse --native 'xaudio2_7' --protonver 5.*"
+game_proton_options="--restart-pulse --noesync --native 'xaudio2_7' --protonver 5.*"
 game_wine_options="--restart-pulse --native 'xaudio2_7'"
 game_protontricks=""
 game_winetricks=""

--- a/runners/proton-launcher.sh
+++ b/runners/proton-launcher.sh
@@ -30,6 +30,8 @@ OPTIONS:
 
 	--int-scaling	enable integer scaling
 
+	--keep-pulse	do not restart pulseaudio (default)
+
 	-n,--native	specify dlls which should prefer native versions
 			should be a quoted space-separated list
 			eg.: -n 'xaudio2_7 d3d9'
@@ -119,6 +121,10 @@ while [ "$parsing_args" == "true" ]; do
 
 		--int-scaling)
 			proton_extra_evs+=("WINE_FULLSCREEN_INTEGER_SCALING=1"); shift 1
+			;;
+
+		--keep-pulse)
+			restart_pulse=false; shift 1
 			;;
 
 		-n|--native)

--- a/runners/wine-launcher.sh
+++ b/runners/wine-launcher.sh
@@ -22,6 +22,8 @@ OPTIONS:
 
 	--int-scaling	enable integer scaling
 
+	--keep-pulse	do not restart pulseaudio (default)
+
 	-n,--native	specify dlls which should prefer native versions
 			should be a quoted space-separated list
 			eg.: -n 'xaudio2_7 d3d9'
@@ -97,6 +99,10 @@ while [ "$parsing_args" == "true" ]; do
 
 		--int-scaling)
 			wine_extra_evs+=("WINE_FULLSCREEN_INTEGER_SCALING=1"); shift 1
+			;;
+
+		--keep-pulse)
+			restart_pulse=false; shift 1
 			;;
 
 		-n|--native)


### PR DESCRIPTION
As noted in #32, users may want to restart pulse audio. The option `keep-pulse` was added to both Proton and Wine launchers to override a previously passed `restart-pulse`, this will allow users to control the behaviour from within Lutris.

It was also indicated that Fallout 4 may run better without esync, so that option was made default.