### PR TITLE
Don't restart Pulseaudio by default

### DIFF
--- a/gamesinfo/fallout3.sh
+++ b/gamesinfo/fallout3.sh
@@ -14,8 +14,8 @@ else
 	game_steam_subdirectory="Fallout 3 goty"
 fi
 game_appid=$fo3_appid
-game_proton_options="--restart-pulse --protonver 5.*"
-game_wine_options="--restart-pulse"
+game_proton_options="--protonver 5.*"
+game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/fallout4.sh
+++ b/gamesinfo/fallout4.sh
@@ -1,7 +1,7 @@
 game_steam_subdirectory="Fallout 4"
 game_appid=377160
-game_proton_options="--restart-pulse --noesync --native 'xaudio2_7' --protonver 5.*"
-game_wine_options="--restart-pulse --native 'xaudio2_7'"
+game_proton_options="--noesync --native 'xaudio2_7' --protonver 5.*"
+game_wine_options="--native 'xaudio2_7'"
 game_protontricks=""
 game_winetricks=""
 

--- a/gamesinfo/morrowind.sh
+++ b/gamesinfo/morrowind.sh
@@ -1,7 +1,7 @@
 game_steam_subdirectory="Morrowind"
 game_appid=22320
-game_proton_options="--restart-pulse --protonver 5.*"
-game_wine_options="--restart-pulse"
+game_proton_options="--protonver 5.*"
+game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/newvegas.sh
+++ b/gamesinfo/newvegas.sh
@@ -1,7 +1,7 @@
 game_steam_subdirectory="Fallout New Vegas"
 game_appid=22380
-game_proton_options="--restart-pulse --protonver 5.*"
-game_wine_options="--restart-pulse"
+game_proton_options="--protonver 5.*"
+game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/oblivion.sh
+++ b/gamesinfo/oblivion.sh
@@ -1,7 +1,7 @@
 game_steam_subdirectory="Oblivion"
 game_appid=22330
-game_proton_options="--restart-pulse --protonver 5.*"
-game_wine_options="--restart-pulse"
+game_proton_options="--protonver 5.*"
+game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/skyrim.sh
+++ b/gamesinfo/skyrim.sh
@@ -1,7 +1,7 @@
 game_steam_subdirectory="Skyrim"
 game_appid=72850
-game_proton_options="--restart-pulse --protonver 5.*"
-game_wine_options="--restart-pulse"
+game_proton_options="--protonver 5.*"
+game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"
 

--- a/gamesinfo/skyrimspecialedition.sh
+++ b/gamesinfo/skyrimspecialedition.sh
@@ -1,7 +1,7 @@
 game_steam_subdirectory="Skyrim Special Edition"
 game_appid=489830
-game_proton_options="--restart-pulse --native 'xaudio2_7' --protonver 5.*"
-game_wine_options="--restart-pulse --native 'xaudio2_7'"
+game_proton_options="--native 'xaudio2_7' --protonver 5.*"
+game_wine_options="--native 'xaudio2_7'"
 game_protontricks=""
 game_winetricks=""
 

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -13,7 +13,7 @@ script:
     - find_library_for_appid: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.0-utils/find-library-for-appid.sh
 
     # supported games info
-    - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.2-gamesinfo/gamesinfo.tar.gz
+    - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.4-gamesinfo/gamesinfo.tar.gz
 
     # mo2/game runners
     - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.2-runners/proton-launcher.sh


### PR DESCRIPTION
Restarting Pulseaudio can improve issues with audio crackling in-game but for many users restarting Pulseaudio can cause problems. #47 has shown restarting Pulseaudio causes issues with bluetooth devices and users on Reddit have reported it can cause issues with some not-so-common audio related kernel modules.

Documentation from `proton-launcher.sh --help` also suggests the default behaviour is to not reset Pulseaudio. While that's true for the script, it's not true for the project as a whole seeing as `--restart-pulse` is used in every installation.