### PR TITLE
Fixed installation of Russian version of New Vegas

### DIFF
--- a/gamesinfo/fallout3.sh
+++ b/gamesinfo/fallout3.sh
@@ -4,6 +4,7 @@ fo3_possible_appids=(22300 22370)
 for fo3_appid in "${fo3_possible_appids[@]}"; do
 	fo3_library=$("$CACHE/utils/find-library-for-appid.sh" $fo3_appid)
 	if [ -d "$fo3_library" ]; then
+		steam_library="$fo3_library"
 		break
 	fi
 done

--- a/gamesinfo/newvegas.sh
+++ b/gamesinfo/newvegas.sh
@@ -1,5 +1,16 @@
+# global version and russion version are different games on steam
+newvegas_possible_appids=(22380 22490)
+
+for newvegas_appid in "${newvegas_possible_appids[@]}"; do
+	newvegas_library=$("$CACHE/utils/find-library-for-appid.sh" $newvegas_appid)
+	if [ -d "$newvegas_library" ]; then
+		steam_library="$newvegas_library"
+		break
+	fi
+done
+
 game_steam_subdirectory="Fallout New Vegas"
-game_appid=22380
+game_appid=$newvegas_appid
 game_proton_options="--protonver 5.*"
 game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -13,7 +13,7 @@ script:
     - find_library_for_appid: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.0-utils/find-library-for-appid.sh
 
     # supported games info
-    - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.4-gamesinfo/gamesinfo.tar.gz
+    - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.5-gamesinfo/gamesinfo.tar.gz
 
     # mo2/game runners
     - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.6.2-runners/proton-launcher.sh
@@ -183,7 +183,9 @@ script:
                     mo2_tricks="vcrun2019"
                     mo2_options=""
 
-                    steam_library=$("$CACHE/utils/find-library-for-appid.sh" $game_appid)
+                    if [ -z "$steam_library" ]; then
+                        steam_library=$("$CACHE/utils/find-library-for-appid.sh" $game_appid)
+                    fi
 
                     if [ ! -d "$steam_library" ]; then
                         "$CACHE/utils/dialog.sh" errorbox \


### PR DESCRIPTION
The Russion version of Fallout New Vegas is a completely different game on Steam. Since the installer did not account for that, installation would fail.