### PR TITLE
Disable Lutris runtime

### DIFF
--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -38,6 +38,9 @@ script:
     game:
         exe: $GAMEDIR/run.sh
 
+    system:
+        disable_runtime: true
+
     installer:
     - input_menu:
         description: |-


### PR DESCRIPTION
As seen in #49 Lutris sets unwanted environment variables by default. By disabling the Lutris runtime for the game, these unwanted environment variables should be gone.