### PR TITLE
Reset LD_LIBRARY_PATH inside Lutris

### DIFF
--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -160,6 +160,9 @@ script:
     ###    prepare prefix    ###
     - execute:
         command: |
+            # clear envs set by Lutris
+            export LD_LIBRARY_PATH=""
+
             nexus_game_id=$INPUT_NEXUS_GAME_ID
             runner=$INPUT_RUNNER
 


### PR DESCRIPTION
As seen in #49 Lutris might set LD_LIBRARY_PATH unnecessarily. This could be the cause for newer versions of Zenity failing inside Lutris.