### PR TITLE
Fix Steam runtime for non Ubuntu based distros

### DIFF
--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -16,10 +16,10 @@ script:
     - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.4-gamesinfo/gamesinfo.tar.gz
 
     # mo2/game runners
-    - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.3-runners/proton-launcher.sh
-    - wine_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.3-runners/wine-launcher.sh
-    - nxm_broker: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.3-runners/modorganizer2-nxm-broker.sh
-    - nxm_mime_handler: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.3-runners/modorganizer2-nxm-handler.desktop
+    - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.5-runners/proton-launcher.sh
+    - wine_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.5-runners/wine-launcher.sh
+    - nxm_broker: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.5-runners/modorganizer2-nxm-broker.sh
+    - nxm_mime_handler: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.5-runners/modorganizer2-nxm-handler.desktop
 
     # modding tools
     - openjdk: https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_x64_windows_8u252b09.zip

--- a/runners/proton-launcher.sh
+++ b/runners/proton-launcher.sh
@@ -326,7 +326,7 @@ fi
 ###    FIND PROTON EXECUTABLE    ###
 
 ###    BUILD LD_LIBRARY_PATH    ###
-steam_rundir=$(readlink -f "$steam_dir/bin32")/steam-runtime
+steam_rundir="$steam_dir/ubuntu12_32/steam-runtime"
 
 library_path=$LD_LIBRARY_PATH
 if [ -d "$steam_rundir" ] && [ -z "$library_path" ]; then

--- a/runners/wine-launcher.sh
+++ b/runners/wine-launcher.sh
@@ -275,7 +275,7 @@ esac
 ###    BUILD LD_LIBRARY_PATH    ###
 library_path=$LD_LIBRARY_PATH
 if [ -d "$steam_dir" ] && [ -z "$library_path" ]; then
-	steam_rundir=$(readlink "$steam_dir/bin32")/steam-runtime
+	steam_rundir="$steam_dir/ubuntu12_32/steam-runtime"
 
 	steam_pinned_libs="$steam_rundir/pinned_libs_32:$steam_rundir/pinned_libs_64"
 


### PR DESCRIPTION
Steam seems to only create the `bin32` symlink on Ubuntu based distros and directly uses `ubuntu12_32` everywhere else. As seen in #93 