### PR TITLE
Rollback Wabbajack support

### DIFF
--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -215,7 +215,7 @@ script:
                     ;;
 
                 wine)
-                    mo2_tricks="vcrun2019"
+                    mo2_tricks="vcrun2019 dotnet40"
                     mo2_options="--proton-wine --winever 5.*"
 
                     "$CACHE/utils/dialog.sh" warnbox \

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -188,7 +188,7 @@ script:
 
             case "$runner" in
                 proton)
-                    mo2_tricks="vcrun2019 dotnet48"
+                    mo2_tricks="vcrun2019"
                     mo2_options=""
 
                     if [ -z "$steam_library" ]; then
@@ -215,7 +215,7 @@ script:
                     ;;
 
                 wine)
-                    mo2_tricks="vcrun2019 dotnet48"
+                    mo2_tricks="vcrun2019"
                     mo2_options="--proton-wine --winever 5.*"
 
                     "$CACHE/utils/dialog.sh" warnbox \


### PR DESCRIPTION
`dotnet48` was added to improve Wabbajack support as requested on #93. Manjaro and Arch have shown to not support `dotnet48` very well.

While this is not a bug on our end, it is better to instruct people wanting to use Wabbajack to install `dotnet48` than to instruct users of popular distributions to fix hard to debug errors.

Closes #108 #111