### PR TITLE
Fix library path building

### DIFF
--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -16,8 +16,8 @@ script:
     - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.8.3-gamesinfo/gamesinfo.tar.gz
 
     # mo2/game runners
-    - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.5-runners/proton-launcher.sh
-    - wine_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.7.5-runners/wine-launcher.sh
+    - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.8.4-runners/proton-launcher.sh
+    - wine_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.8.4-runners/wine-launcher.sh
 
     # download handlers
     - nxm_broker: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.8.2-handlers/modorganizer2-nxm-broker.sh

--- a/runners/proton-launcher.sh
+++ b/runners/proton-launcher.sh
@@ -330,27 +330,39 @@ steam_rundir="$steam_dir/ubuntu12_32/steam-runtime"
 
 library_path=$LD_LIBRARY_PATH
 if [ -d "$steam_rundir" ] && [ -z "$library_path" ]; then
-	proton_libs="$proton_dir/dist/lib64:$proton_dir/dist/lib"
+	# these will be added by proton, no need to specify them manually
+	# proton_libs=("$proton_dir/dist/lib64" "$proton_dir/dist/lib")
 
-	steam_pinned_libs="$steam_rundir/pinned_libs_32:$steam_rundir/pinned_libs_64"
+	steam_pinned_libs=("$steam_rundir/pinned_libs_32" "$steam_rundir/pinned_libs_64")
 
-	steam_32libs="$steam_rundir/i386/lib/i368-linux-gnu:$steam_rundir/i386/lib:$steam_rundir/i386/usr/lib/i386-linux-gnu:$steam_rundir/i386/usr/lib"
-	steam_64libs="$steam_rundir/amd64/lib/x86_64-linux-gnu:$steam_rundir/amd64/lib:$steam_rundir/amd64/usr/lib/x86_64-linux-gnu:$steam_rundir/amd64/usr/lib"
-
-	steam_libs="$proton_libs:$steam_pinned_libs:$steam_32libs:$steam_64libs"
-
-	system_libs=$( \
-				ldconfig -N -v 2>/dev/null \
-			|	grep -oE '^/[^:]+' \
-			| tr '\n' ':' \
-			| sed 's/:$//' \
+	steam_supplementary_libs=( \
+		"$steam_rundir/lib/i368-linux-gnu" \
+		"$steam_rundir/usr/lib/i386-linux-gnu" \
+		"$steam_rundir/lib/x86_64-linux-gnu" \
+		"$steam_rundir/usr/lib/x86_64-linux-gnu" \
+		"$steam_rundir/lib" \
+		"$steam_rundir/usr/lib" \
 	)
 
+	system_libs=($( \
+		ldconfig -N -v 2>/dev/null | grep -oE '^/[^:]+' \
+	))
+
 	if [ "$prefer_system_libs" == "true" ]; then
-		library_path="$system_libs:$steam_libs"
+		libs=( \
+			"${system_libs[@]}" \
+			"${steam_pinned_libs[@]}" \
+			"${steam_supplementary_libs[@]}" \
+		)
 	else
-		library_path="$steam_libs:$system_libs"
+		libs=( \
+			"${steam_pinned_libs[@]}" \
+			"${system_libs[@]}" \
+			"${steam_supplementary_libs[@]}" \
+		)
 	fi
+
+	library_path=$(IFS=: ; echo "${libs[*]}")
 else
 	echo "WARN: could not find Steam runtime, you might experience problems" >&2
 fi

--- a/runners/wine-launcher.sh
+++ b/runners/wine-launcher.sh
@@ -277,27 +277,44 @@ library_path=$LD_LIBRARY_PATH
 if [ -d "$steam_dir" ] && [ -z "$library_path" ]; then
 	steam_rundir="$steam_dir/ubuntu12_32/steam-runtime"
 
-	steam_pinned_libs="$steam_rundir/pinned_libs_32:$steam_rundir/pinned_libs_64"
+	if [ "$bin_supplier" == "proton" ]; then
+		proton_libs=("$proton_dir/dist/lib64" "$proton_dir/dist/lib")
+	else
+		proton_libs=()
+	fi
 
-	system_libs=$( \
-				ldconfig -N -v 2>/dev/null \
-			|	grep -oE '^/[^:]+' \
-			| tr '\n' ':' \
-			| sed 's/:$//' \
+	steam_pinned_libs=("$steam_rundir/pinned_libs_32" "$steam_rundir/pinned_libs_64")
+
+	steam_supplementary_libs=( \
+		"$steam_rundir/lib/i368-linux-gnu" \
+		"$steam_rundir/usr/lib/i386-linux-gnu" \
+		"$steam_rundir/lib/x86_64-linux-gnu" \
+		"$steam_rundir/usr/lib/x86_64-linux-gnu" \
+		"$steam_rundir/lib" \
+		"$steam_rundir/usr/lib" \
 	)
 
-	steam_32libs="$steam_rundir/i386/lib/i368-linux-gnu:$steam_rundir/i386/lib:$steam_rundir/i386/usr/lib/i386-linux-gnu:$steam_rundir/i386/usr/lib"
-	steam_64libs="$steam_rundir/amd64/lib/x86_64-linux-gnu:$steam_rundir/amd64/lib:$steam_rundir/amd64/usr/lib/x86_64-linux-gnu:$steam_rundir/amd64/usr/lib"
-
-	if [ "$bin_supplier" == "proton" ]; then
-		proton_libs="$proton_dir/lib64:$proton_dir/lib:"
-	fi
+	system_libs=($( \
+		ldconfig -N -v 2>/dev/null | grep -oE '^/[^:]+' \
+	))
 
 	if [ "$prefer_system_libs" == "true" ]; then
-		library_path="$system_libs:${proton_libs}$steam_pinned_libs:$steam_32libs:$steam_64libs"
+		libs=( \
+			"${system_libs[@]}" \
+			"${proton_libs[@]}" \
+			"${steam_pinned_libs[@]}" \
+			"${steam_supplementary_libs[@]}" \
+		)
 	else
-		library_path="${proton_libs}$steam_pinned_libs:$system_libs:$steam_32libs:$steam_64libs"
+		libs=( \
+			"${proton_libs[@]}" \
+			"${steam_pinned_libs[@]}" \
+			"${system_libs[@]}" \
+			"${steam_supplementary_libs[@]}" \
+		)
 	fi
+
+	library_path=$(IFS=: ; echo "${libs[*]}")
 fi
 ###    BUILD LD_LIBRARY_PATH    ###
 


### PR DESCRIPTION
Debugging side by side with Steam showed differences between how the Steam client builds its library path and how the launcher was doing it. This could be the cause for #120 and #101 

This PR removes the differences and attempts to improve readability so that future problems can be avoided.