### PR TITLE
Freeze Proton version to 5.0

### DIFF
--- a/gamesinfo/fallout3.sh
+++ b/gamesinfo/fallout3.sh
@@ -15,7 +15,7 @@ else
 	game_steam_subdirectory="Fallout 3 goty"
 fi
 game_appid=$fo3_appid
-game_proton_options="--protonver 5.*"
+game_proton_options="--protonver 5.0"
 game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"

--- a/gamesinfo/fallout4.sh
+++ b/gamesinfo/fallout4.sh
@@ -1,6 +1,6 @@
 game_steam_subdirectory="Fallout 4"
 game_appid=377160
-game_proton_options="--noesync --native 'xaudio2_7' --protonver 5.* -e 'PULSE_LATENCY_MSEC=90'"
+game_proton_options="--noesync --native 'xaudio2_7' --protonver 5.0 -e 'PULSE_LATENCY_MSEC=90'"
 game_wine_options="--native 'xaudio2_7'"
 game_protontricks=""
 game_winetricks=""

--- a/gamesinfo/morrowind.sh
+++ b/gamesinfo/morrowind.sh
@@ -1,6 +1,6 @@
 game_steam_subdirectory="Morrowind"
 game_appid=22320
-game_proton_options="--protonver 5.*"
+game_proton_options="--protonver 5.0"
 game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"

--- a/gamesinfo/newvegas.sh
+++ b/gamesinfo/newvegas.sh
@@ -15,7 +15,7 @@ else
 	game_steam_subdirectory="Fallout New Vegas enplczru"
 fi
 game_appid=$newvegas_appid
-game_proton_options="--protonver 5.*"
+game_proton_options="--protonver 5.0"
 game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"

--- a/gamesinfo/oblivion.sh
+++ b/gamesinfo/oblivion.sh
@@ -1,6 +1,6 @@
 game_steam_subdirectory="Oblivion"
 game_appid=22330
-game_proton_options="--protonver 5.*"
+game_proton_options="--protonver 5.0"
 game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"

--- a/gamesinfo/skyrim.sh
+++ b/gamesinfo/skyrim.sh
@@ -1,6 +1,6 @@
 game_steam_subdirectory="Skyrim"
 game_appid=72850
-game_proton_options="--protonver 5.*"
+game_proton_options="--protonver 5.0"
 game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"

--- a/gamesinfo/skyrimspecialedition.sh
+++ b/gamesinfo/skyrimspecialedition.sh
@@ -1,6 +1,6 @@
 game_steam_subdirectory="Skyrim Special Edition"
 game_appid=489830
-game_proton_options="--native 'xaudio2_7' --protonver 5.* -e 'PULSE_LATENCY_MSEC=90'"
+game_proton_options="--native 'xaudio2_7' --protonver 5.0 -e 'PULSE_LATENCY_MSEC=90'"
 game_wine_options="--native 'xaudio2_7'"
 game_protontricks=""
 game_winetricks=""

--- a/installers/modorganizer2.yml
+++ b/installers/modorganizer2.yml
@@ -13,7 +13,7 @@ script:
     - find_library_for_appid: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.8.4-utils/find-library-for-appid.sh
 
     # supported games info
-    - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.8.3-gamesinfo/gamesinfo.tar.gz
+    - gamesinfo: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.8.5-gamesinfo/gamesinfo.tar.gz
 
     # mo2/game runners
     - proton_launcher: https://github.com/rockerbacon/lutris-skyrimse-installers/releases/download/2.8.4-runners/proton-launcher.sh
@@ -71,7 +71,7 @@ script:
 
             If yes, ensure the following before continuing:
                 * The game was run at least once on Steam
-                * The game is configured to use Proton 5. On Steam: right click the game > Properties > tab "General" > Force the use of a specific Steam Play compatibility tool
+                * The game is configured to use Proton 5.0 - On Steam: right click the game > Properties > tab "General" > Force the use of a specific Steam Play compatibility tool
 
         id: RUNNER
         options:


### PR DESCRIPTION
Fixes #161 

Latest Proton release (5.13) seems to have broken MO2. This PR enforces usage of version 5.0 in the games' configurations.