### PR TITLE
Set pulse latency for Skyrim LE

### DIFF
--- a/gamesinfo/skyrim.sh
+++ b/gamesinfo/skyrim.sh
@@ -1,6 +1,6 @@
 game_steam_subdirectory="Skyrim"
 game_appid=72850
-game_proton_options="--protonver 5.0"
+game_proton_options="--protonver 5.0 -e 'PULSE_LATENCY_MSEC=90'"
 game_wine_options=""
 game_protontricks="d3dcompiler_43 d3dx9"
 game_winetricks="d3dcompiler_43 d3dx9"


### PR DESCRIPTION
From my personal testing, setting pulse latency to 90ms seems to improve audio in Skyrim LE.