### PR TITLE
Arch Linux path finding fix

### DIFF
--- a/runners/proton-launcher.sh
+++ b/runners/proton-launcher.sh
@@ -390,7 +390,7 @@ run_proton="
 	SteamAppId=$appid \\
 	${proton_extra_envs[*]} \\
 	\\
-	'$proton_dir/proton' run '$executable' $([ -n "$1" ] && printf " '%s'" "$@")
+	'$proton_dir/proton' runinprefix '$executable' $([ -n "$1" ] && printf " '%s'" "$@")
 "
 
 echo -e "\n$run_proton\n"

--- a/utils/find-library-for-appid.sh
+++ b/utils/find-library-for-appid.sh
@@ -12,6 +12,7 @@ fi
 steam_install_candidates=( \
 	"$steam_dir" \
 	"$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam" \
+	"$HOME/.local/share/Steam" \
 )
 for steam_install in "${steam_install_candidates[@]}"; do
 	echo "Searching for Steam in '$steam_install'" >&2


### PR DESCRIPTION
This installer fails to find games on Arch because of a path finding issue. This adds the path where games are stored on Arch to the array. It may need to have an if statement added to detect OS if this causes issues on the other operating systems.
```

➜ sh .cache/lutris/installer/mod-organizer-2/utils/find-library-for-appid.sh 377160
Searching for Steam in '/home/lily/.local/share/Steam'
Found Steam
Searching for Steam in '/home/lily/.var/app/com.valvesoftware.Steam/.local/share/Steam'
Steam not found in this install path
Searching for Steam in '/home/lily/.local/share/'
Found Steam
grep: /home/lily/.local/share//steam/steamapps/libraryfolders.vdf: No such file or directory
Searching for game in library '/home/lily/.local/share//steam'
ERROR: could not find game with APPID '377160'
/home/lily/.cache/lutris/installer/mod-organizer-2/utils/find-library-for-appid.sh: line 50: return: can only `return' from a function or sourced script

~ 
➜ .cache/lutris/installer/mod-organizer-2/utils/find-library-for-appid.sh 377160
Searching for Steam in '/home/lily/.local/share/Steam'
Found Steam
Searching for Steam in '/home/lily/.var/app/com.valvesoftware.Steam/.local/share/Steam'
Steam not found in this install path
Searching for Steam in '/home/lily/.local/share/Steam'
Found Steam
Searching for game in library '/home/lily/.local/share/Steam'
Found game
/home/lily/.local/share/Steam
/home/lily/.cache/lutris/installer/mod-organizer-2/utils/find-library-for-appid.sh: line 45: return: can only `return' from a function or sourced script`
```